### PR TITLE
refactor(src/core/renderers): changing the way to determine the templ…

### DIFF
--- a/mocks/app/index.tsx
+++ b/mocks/app/index.tsx
@@ -1,4 +1,19 @@
 import React from 'react';
 
-export * from './templates/Welcome';
-export * from './templates/ResetPassword';
+import { Welcome } from './templates/Welcome';
+import { ResetPassword } from './templates/ResetPassword';
+
+export default function App() {
+  return {
+    Welcome: {
+      componentFunction: Welcome,
+      props: {
+        prefix: 'string',
+      },
+    },
+    ResetPassword: {
+      componentFunction: ResetPassword,
+      props: {},
+    },
+  };
+}

--- a/mocks/built-app/index.js
+++ b/mocks/built-app/index.js
@@ -3,29 +3,23 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.default = App;
 
 var _Welcome = require("./templates/Welcome");
 
-Object.keys(_Welcome).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _Welcome[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _Welcome[key];
-    }
-  });
-});
-
 var _ResetPassword = require("./templates/ResetPassword");
 
-Object.keys(_ResetPassword).forEach(function (key) {
-  if (key === "default" || key === "__esModule") return;
-  if (key in exports && exports[key] === _ResetPassword[key]) return;
-  Object.defineProperty(exports, key, {
-    enumerable: true,
-    get: function () {
-      return _ResetPassword[key];
+function App() {
+  return {
+    Welcome: {
+      componentFunction: _Welcome.Welcome,
+      props: {
+        prefix: 'string'
+      }
+    },
+    ResetPassword: {
+      componentFunction: _ResetPassword.ResetPassword,
+      props: {}
     }
-  });
-});
+  };
+}

--- a/mocks/cli-app/index.tsx
+++ b/mocks/cli-app/index.tsx
@@ -1,4 +1,19 @@
 import React from 'react';
 
-export * from './templates/Welcome';
-export * from './templates/ResetPassword';
+import { Welcome } from './templates/Welcome';
+import { ResetPassword } from './templates/ResetPassword';
+
+export default function App() {
+  return {
+    Welcome: {
+      componentFunction: Welcome,
+      props: {
+        prefix: 'string',
+      },
+    },
+    ResetPassword: {
+      componentFunction: ResetPassword,
+      props: {},
+    },
+  };
+}

--- a/src/core/renderers/build/build.test.ts
+++ b/src/core/renderers/build/build.test.ts
@@ -27,6 +27,5 @@ describe('build', () => {
   it('should build files to dist', async () => {
     await build.run();
     expect(fs.existsSync('mocks/test-build/dist/index.js')).toBe(true);
-    expect(true).toBeTruthy();
   });
 });

--- a/src/core/renderers/render/index.ts
+++ b/src/core/renderers/render/index.ts
@@ -2,6 +2,7 @@ import { IRender } from '../../interfaces/IRender';
 import path from 'path';
 import fs from 'fs';
 import { ReactRender } from './ReactRender';
+import { IMailAppConfig } from '../../../interfaces/IMailApp';
 
 export class Render implements IRender {
   constructor(private inputPath: string) {}
@@ -15,13 +16,15 @@ export class Render implements IRender {
 
     const indexFile = await import(indexFilePath);
 
-    const templateReactElement = indexFile[templateName];
+    const mailAppConfig: IMailAppConfig = indexFile.default();
 
-    if (!templateReactElement) {
+    const template = mailAppConfig[templateName];
+
+    if (!template) {
       throw new Error('Template not found: ' + templateName);
     }
 
-    const reactRender = new ReactRender(templateReactElement, variables);
+    const reactRender = new ReactRender(template.componentFunction, variables);
 
     const { htmlCode, styleTag } = await reactRender.run();
 

--- a/src/interfaces/IMailApp.ts
+++ b/src/interfaces/IMailApp.ts
@@ -6,5 +6,5 @@ export interface IMailAppConfig {
 }
 
 export interface IMailAppProps {
-  [key: string]: string | number | boolean | IMailAppProps;
+  [key: string]: string | number | boolean | IMailAppProps | IMailAppProps[];
 }

--- a/src/interfaces/IMailApp.ts
+++ b/src/interfaces/IMailApp.ts
@@ -1,0 +1,10 @@
+export interface IMailAppConfig {
+  [key: string]: {
+    componentFunction: (props?: any) => JSX.Element;
+    props: IMailAppProps;
+  };
+}
+
+export interface IMailAppProps {
+  [key: string]: string | number | boolean | IMailAppProps;
+}


### PR DESCRIPTION
…ates

Previously every component that was exported from within the index file became a template, but now
it doesn't work anymore so now the index file must export a function as default and this function
must return an object in which each key of it is a different template, and receives an object with
template information

fix #21