### PR TITLE
fix(packages/core): use renderToStaticMarkup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 
 # turbo
 .turbo
+
+# jsx-mail
+html-check
+css-check

--- a/examples/error-react-hook/README.md
+++ b/examples/error-react-hook/README.md
@@ -1,0 +1,3 @@
+# IMPORTANT
+
+If you run this example you will have an error. This because the jsx-mail does not support react hooks

--- a/examples/error-react-hook/app/index.tsx
+++ b/examples/error-react-hook/app/index.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { Group } from '@jsx-mail/components';
+
+export default function App() {
+  return {
+    Welcome: {
+      componentFunction: ({ name }) => {
+        const [state, setState] = React.useState(0);
+
+        setState(1);
+
+        return (
+          <Group>
+            Hello {name}. State: {state}
+          </Group>
+        );
+      },
+      props: {
+        name: 'string',
+      },
+    },
+  };
+}

--- a/examples/error-react-hook/index.js
+++ b/examples/error-react-hook/index.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line
+const jsxMail = require('jsx-mail');
+
+jsxMail
+  .render('Welcome', {
+    name: 'John Doe',
+  })
+  .then(result => {
+    console.log(result);
+  });

--- a/examples/error-react-hook/jsx-mail.json
+++ b/examples/error-react-hook/jsx-mail.json
@@ -1,0 +1,7 @@
+{
+  "mailPath": "./app",
+  "allowHtmlNotRecommended": false,
+  "allowCssNotRecommended": false,
+  "servePort": "8080",
+  "lang": "pt-BR"
+}

--- a/examples/error-react-hook/package.json
+++ b/examples/error-react-hook/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "error-react-hook",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "Theryston",
+  "license": "MIT",
+  "dependencies": {
+    "@jsx-mail/components": "workspace:^1.0.0",
+    "jsx-mail": "workspace:^1.0.0",
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.17"
+  }
+}

--- a/packages/core/src/renderers/render/ReactRender/index.ts
+++ b/packages/core/src/renderers/render/ReactRender/index.ts
@@ -1,5 +1,5 @@
 import { ServerStyleSheet } from 'styled-components';
-import { renderToString } from 'react-dom/server';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 export class ReactRender {
   sheet: ServerStyleSheet;
@@ -18,7 +18,7 @@ export class ReactRender {
     styleTag: string;
   }> {
     const code = this.sheet.collectStyles(this.inicialCode(this.variables));
-    const htmlCode = renderToString(code);
+    const htmlCode = renderToStaticMarkup(code);
     const styleTag = this.sheet.getStyleTags();
     return {
       htmlCode,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,107 +35,18 @@ importers:
       prettier: 2.7.1
       turbo: 1.4.3
 
-  examples/use-component-button:
+  examples/error-react-hook:
     specifiers:
       '@jsx-mail/components': workspace:^1.0.0
-      '@jsx-mail/core': workspace:*
       '@types/react': ^18.0.17
-      '@types/styled-components': ^5.1.26
       jsx-mail: workspace:^1.0.0
       react: ^18.2.0
-      styled-components: ^5.3.5
-    dependencies:
-      '@jsx-mail/components': link:../../packages/components
-      '@jsx-mail/core': link:../../packages/core
-      jsx-mail: link:../../packages/jsx-mail
-      react: 18.2.0
-      styled-components: 5.3.5_pumtretovylab5lwhztzjp2kuy
-    devDependencies:
-      '@types/react': 18.0.17
-      '@types/styled-components': 5.1.26
-
-  examples/use-component-group:
-    specifiers:
-      '@jsx-mail/components': workspace:^1.0.0
-      '@types/react': ^18.0.17
-      '@types/styled-components': ^5.1.26
-      react: ^18.2.0
-      styled-components: ^5.3.5
-    dependencies:
-      '@jsx-mail/components': link:../../packages/components
-      react: 18.2.0
-      styled-components: 5.3.5_pumtretovylab5lwhztzjp2kuy
-    devDependencies:
-      '@types/react': 18.0.17
-      '@types/styled-components': 5.1.26
-
-  examples/use-component-image:
-    specifiers:
-      '@jsx-mail/components': workspace:^1.0.0
-      '@types/react': ^18.0.17
-      '@types/styled-components': ^5.1.26
-      jsx-mail: workspace:^1.0.0
-      react: ^18.2.0
-      styled-components: ^5.3.5
     dependencies:
       '@jsx-mail/components': link:../../packages/components
       jsx-mail: link:../../packages/jsx-mail
       react: 18.2.0
-      styled-components: 5.3.5_pumtretovylab5lwhztzjp2kuy
     devDependencies:
       '@types/react': 18.0.17
-      '@types/styled-components': 5.1.26
-
-  examples/use-core:
-    specifiers:
-      '@jsx-mail/components': workspace:^1.0.0
-      '@jsx-mail/core': workspace:*
-      '@types/react': ^18.0.17
-      '@types/styled-components': ^5.1.26
-      react: ^18.2.0
-      styled-components: ^5.3.5
-    dependencies:
-      '@jsx-mail/components': link:../../packages/components
-      '@jsx-mail/core': link:../../packages/core
-      react: 18.2.0
-      styled-components: 5.3.5_pumtretovylab5lwhztzjp2kuy
-    devDependencies:
-      '@types/react': 18.0.17
-      '@types/styled-components': 5.1.26
-
-  examples/use-jsxm:
-    specifiers:
-      '@jsx-mail/components': workspace:^1.0.0
-      '@types/react': ^18.0.17
-      '@types/styled-components': ^5.1.26
-      jsx-mail: workspace:^1.0.0
-      react: ^18.2.0
-      styled-components: ^5.3.5
-    dependencies:
-      '@jsx-mail/components': link:../../packages/components
-      jsx-mail: link:../../packages/jsx-mail
-      react: 18.2.0
-      styled-components: 5.3.5_pumtretovylab5lwhztzjp2kuy
-    devDependencies:
-      '@types/react': 18.0.17
-      '@types/styled-components': 5.1.26
-
-  examples/with-styled-components:
-    specifiers:
-      '@jsx-mail/components': workspace:^1.0.0
-      '@types/react': ^18.0.17
-      '@types/styled-components': ^5.1.26
-      jsx-mail: workspace:^1.0.0
-      react: ^18.2.0
-      styled-components: ^5.3.5
-    dependencies:
-      '@jsx-mail/components': link:../../packages/components
-      jsx-mail: link:../../packages/jsx-mail
-      react: 18.2.0
-      styled-components: 5.3.5_pumtretovylab5lwhztzjp2kuy
-    devDependencies:
-      '@types/react': 18.0.17
-      '@types/styled-components': 5.1.26
 
   packages/cli:
     specifiers:


### PR DESCRIPTION
we use reactdom's render string but it is not recommended when we just want to use react to get
static html